### PR TITLE
Allow cidrvalidate to work with non-compressed IPv6 address

### DIFF
--- a/lib/Net/CIDR.pm
+++ b/lib/Net/CIDR.pm
@@ -1218,6 +1218,29 @@ undef.
 
 =cut
 
+sub _compress_ipv6 {
+    # taken from IPv6::Address on CPAN
+    my $str = shift;
+    return '::' if($str eq '0:0:0:0:0:0:0:0');
+    for(my $i=7;$i>1;$i--) {
+            my $zerostr = join(':',split('','0'x$i));
+            ###print "DEBUG: $str $zerostr \n";
+            if($str =~ /:$zerostr$/) {
+                    $str =~ s/:$zerostr$/::/;
+                    return $str;
+            }
+            elsif ($str =~ /:$zerostr:/) {
+                    $str =~ s/:$zerostr:/::/;
+                    return $str;
+            }
+            elsif ($str =~ /^$zerostr:/) {
+                    $str =~ s/^$zerostr:/::/;
+                    return $str;
+            }
+    }
+    return $str;
+}
+
 sub cidrvalidate {
     my $v=shift;
 
@@ -1297,9 +1320,10 @@ sub cidrvalidate {
 
     $v =~ s/([0-9A-Fa-f]+)/_triml0($1)/ge;
 
+	my $compressed = _compress_ipv6($v);
     foreach (addr2cidr($v))
     {
-	return $_ if $_ eq "$v/$suffix";
+	return $_ if $_ eq "$compressed/$suffix";
     }
     return undef;
 }

--- a/t/test.t
+++ b/t/test.t
@@ -133,6 +133,11 @@ else
     print "not ok 11\n";
 }
 
+print
+	+(Net::CIDR::cidrvalidate("2001:4860:4860:0:0:0:0:8888") ? '' : 'not ') . "ok 12\n";
+print
+	+(Net::CIDR::cidrvalidate("2001:4860:4860::8888") ? '' : 'not ') . "ok 13\n";
+
 my @only4 = qw(
     10.0.0.0/24
     10.0.1.0/24
@@ -153,11 +158,11 @@ if (join("",
     Net::CIDR::cidrlookup("10.0.10.1", @only4),
     Net::CIDR::cidrlookup("2001:db8::1", @only4)) eq "100")
 {
-    print "ok 12\n";
+    print "ok 14\n";
 }
 else
 {
-    print "not ok 12\n";
+    print "not ok 14\n";
 }
 
 if (join("",
@@ -165,11 +170,11 @@ if (join("",
     Net::CIDR::cidrlookup("2001:db8:a::1", @only6),
     Net::CIDR::cidrlookup("10.0.0.1", @only6)) eq "100")
 {
-    print "ok 13\n";
+    print "ok 15\n";
 }
 else
 {
-    print "not ok 13\n";
+    print "not ok 15\n";
 }
 
 if (join("",
@@ -178,9 +183,9 @@ if (join("",
     Net::CIDR::cidrlookup("2001:db8:2::1", @dualstack),
     Net::CIDR::cidrlookup("2001:db8:20::1", @dualstack)))
 {
-    print "ok 14\n";
+    print "ok 16\n";
 }
 else
 {
-    print "not ok 14\n";
+    print "not ok 16\n";
 }


### PR DESCRIPTION
`cidrvalidate` checks IPv6 addresses by comparing the input to the output of `addr2cidr`. The values from `addr2cidr` are the compressed form, so will not match a string comparison to the non-compressed input. This fails in Geo::IPinfo, for example (ipinfo/perl#34).

For what it is worth, I'm willing to take up maintenance of this module if you are no longer interested in working on it.